### PR TITLE
Criando propriedade para montagem do link do email

### DIFF
--- a/src/main/java/br/com/agendasus/auth/v1/domain/usecase/AccessRecovery.java
+++ b/src/main/java/br/com/agendasus/auth/v1/domain/usecase/AccessRecovery.java
@@ -29,7 +29,7 @@ public class AccessRecovery {
             String recoveryPasswordHash = UUID.randomUUID().toString();
             userLogin.setHashPasswordRecovery(recoveryPasswordHash);
             dao.merge(userLogin);
-            String linkPasswordRecovery = properties.getSystemUrl() + "/password-recovery/" + recoveryPasswordHash;
+            String linkPasswordRecovery = properties.getAppUrl() + "/password-recovery/" + recoveryPasswordHash;
             String linkInvalidateRecovery = properties.getSystemUrl() + "/invalidate-recovery/" + recoveryPasswordHash;
             notificationService.sendEmailToPasswordRecovery(userLogin, requestIP, linkPasswordRecovery, linkInvalidateRecovery);
         }

--- a/src/main/java/br/com/agendasus/auth/v1/infrastructure/system/SystemProperties.java
+++ b/src/main/java/br/com/agendasus/auth/v1/infrastructure/system/SystemProperties.java
@@ -22,6 +22,7 @@ public class SystemProperties {
 
     @Value("${server.port}") private String appPort;
     @Value("${agendasus.system-url}") private String systemUrl;
+    @Value("${agendasus.app-url}") private String appUrl;
     @Value("${agendasus.token-timeout-minutes}") private Integer tokenTimeoutMinutes;
     @Value("${spring.datasource.server}") private String databaseServer;
     @Value("${spring.datasource.port}") private String databasePort;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,8 +23,7 @@ agendasus.system-url=${SYSTEM_URL:http://localhost:9002}
 agendasus.token-timeout-minutes=300
 
 # App properties
-agendasus.app-url=agendasus.com.br
-
+agendasus.app-url=${APP_URL:agendasus.com.br}
 
 server.port=${APP_PORT:9002}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,10 @@ spring.redis.password=${REDIS_PASSWORD:foobared}
 agendasus.system-url=${SYSTEM_URL:http://localhost:9002}
 agendasus.token-timeout-minutes=300
 
+# App properties
+agendasus.app-url=agendasus.com.br
+
+
 server.port=${APP_PORT:9002}
 
 


### PR DESCRIPTION
Troquei a montagem da url do link para uma maneira que funcione tanto no aplicativo quanto no navegador.

O aplicativo aceita ps prefixos: `http://agendasus.*`  e `http://agendasus-auth.*`
Se for necessário outros padrões ou casos, é preciso ajustar no aplicativo.


Obs: para funcionar corretamente, depende de alteração no agendasus-notification